### PR TITLE
make laser/collision rate configurable

### DIFF
--- a/CalibrationParameterDialog.h
+++ b/CalibrationParameterDialog.h
@@ -123,6 +123,15 @@ public:
         QTextStream(&s) >> adcPerMip;
         return adcPerMip;
     }
+    void setRefRatekHz(float value) {
+        _ui->lineEditRefRatekHz->setText(QString::asprintf("%g", value));
+    }
+    float getRefRatekHz() const {
+        auto s = _ui->lineEditRefRatekHz->text();
+        float refRatekHz = 1.0f;
+        QTextStream(&s) >> refRatekHz;
+        return refRatekHz;
+    }
     quint32 getInitialSteps() const {
         auto s = _ui->lineEditInitAttenSteps->text();
         quint32 steps = 7100;
@@ -215,6 +224,7 @@ private slots:
             }
         }
         _calibrationTasks->setActiveChannelMap(activeChannelMap);
+        _calibrationTasks->setRefRatekHz(getRefRatekHz());
         if (_ui->radioButtonTimeAlign->isChecked()) {
             _calibrationTasks->setMode("TimeAlign");
             _ui->groupChannelStatus->setTitle("Calibration Status - Time Alignment");

--- a/CalibrationTasks.h
+++ b/CalibrationTasks.h
@@ -106,7 +106,7 @@ protected:
         FEE.reset();
         Sleep(10);
         FEE.switchHistogramming(true);
-        int sleepTimeMSec = 500;  // 500e-3 sec
+        int const sleepTimeMSec = 500;  // 500e-3 sec
         Sleep(sleepTimeMSec);
         auto n = FEE.readHistograms(hTime);
         emit logMessage(0, QString::asprintf("Read Histograms(%d)\n\n",n.read));
@@ -116,7 +116,7 @@ protected:
 
         std::array<double,12> meanTime, stdTime;
         std::array<int,12>    timeOK, nEntries;
-        computeMeanStd(FEE, 0, 1e-3*sleepTimeMSec, meanTime,stdTime,timeOK,nEntries);
+        computeMeanStd(FEE, 0, 1e-3f*sleepTimeMSec, meanTime,stdTime,timeOK,nEntries);
         for (auto ch=0; ch<12; ++ch) {
             if (!_activeChannelMap[ch]) {
                 continue;
@@ -231,7 +231,7 @@ protected:
             FEE.writeADCRegisters(adcRegs);
             Sleep(10);
             success = FEE.readCounters(countersOld);
-            Sleep(100); // expect max. 100ms * _refRatekHz entries
+            Sleep(100); // expect max. 100ms * 1e3 * _refRatekHz entries
             success = FEE.readCounters(counters);
             bool nonZeroRates[12] = {false};
             for (int ch=0; ch<12; ++ch  ) {

--- a/CalibrationTasks.h
+++ b/CalibrationTasks.h
@@ -19,6 +19,7 @@ public:
       , _abort(false)
       , _activeChannelMap()
       , _mode("TimeAlign")
+      , _refRatekHz(1)
       , _ADCpMIP(16)
       , _initialSteps(7200)
       , _ipAddress(ipAddress)
@@ -52,6 +53,7 @@ public:
   }
   void setiBd(int i) { _iBd = i; }
   void setMode(QString mode) { _mode = mode; }
+  void setRefRatekHz(float value) {_refRatekHz = value; }
   void setADCpMIP(float value) {_ADCpMIP = value; }
   void setInitialSteps(int value) {_initialSteps = value; }
   void setActiveChannelMap(std::array<bool,12> map) { _activeChannelMap = map; }
@@ -104,7 +106,8 @@ protected:
         FEE.reset();
         Sleep(10);
         FEE.switchHistogramming(true);
-        Sleep(500);
+        int sleepTimeMSec = 500;  // 500e-3 sec
+        Sleep(sleepTimeMSec);
         auto n = FEE.readHistograms(hTime);
         emit logMessage(0, QString::asprintf("Read Histograms(%d)\n\n",n.read));
 
@@ -113,7 +116,7 @@ protected:
 
         std::array<double,12> meanTime, stdTime;
         std::array<int,12>    timeOK, nEntries;
-        computeMeanStd(FEE, 0, meanTime,stdTime,timeOK,nEntries);
+        computeMeanStd(FEE, 0, 1e-3*sleepTimeMSec, meanTime,stdTime,timeOK,nEntries);
         for (auto ch=0; ch<12; ++ch) {
             if (!_activeChannelMap[ch]) {
                 continue;
@@ -192,7 +195,7 @@ protected:
         std::copy(adcRegs, adcRegs+4*12, adcRegsOld);
         quint32 counters[24];
         quint32 countersOld[24];
-        int const m = 20000/200;
+        int const m = 20000/200 + 1; // steps of 200 from 0 to including 20000
         quint32 rates[12][m];
         for (int ch=0; ch<12; ++ch) {
             for (int i=0; i<m; ++i) {
@@ -228,7 +231,7 @@ protected:
             FEE.writeADCRegisters(adcRegs);
             Sleep(10);
             success = FEE.readCounters(countersOld);
-            Sleep(100);
+            Sleep(100); // expect max. 100ms * _refRatekHz entries
             success = FEE.readCounters(counters);
             bool nonZeroRates[12] = {false};
             for (int ch=0; ch<12; ++ch  ) {
@@ -345,6 +348,7 @@ protected:
 private:
     void computeMeanStd(FITelectronics&,
                         int typeHist,
+                        float sleepTimeSec,
                         std::array<double,12>& meanTime,
                         std::array<double,12>& stdTime,
                         std::array<int,12>& timeOK,
@@ -357,6 +361,7 @@ private:
     bool _abort;
     std::array<bool, 12> _activeChannelMap;
     QString _mode;
+    float _refRatekHz;
     float _ADCpMIP;
     int _initialSteps;
     QString _ipAddress;

--- a/calibration.ui
+++ b/calibration.ui
@@ -752,7 +752,7 @@
    </property>
    <property name="geometry">
     <rect>
-     <x>280</x>
+     <x>270</x>
      <y>150</y>
      <width>111</width>
      <height>23</height>
@@ -761,6 +761,48 @@
    <property name="text">
     <string>Restore TimeDelays</string>
    </property>
+  </widget>
+  <widget class="QGroupBox" name="groupBoxRefRate">
+   <property name="geometry">
+    <rect>
+     <x>390</x>
+     <y>130</y>
+     <width>91</width>
+     <height>51</height>
+    </rect>
+   </property>
+   <property name="title">
+    <string>Reference Rate</string>
+   </property>
+   <widget class="QLineEdit" name="lineEditRefRatekHz">
+    <property name="geometry">
+     <rect>
+      <x>10</x>
+      <y>20</y>
+      <width>41</width>
+      <height>20</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>1</string>
+    </property>
+    <property name="alignment">
+     <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+    </property>
+   </widget>
+   <widget class="QLabel" name="label">
+    <property name="geometry">
+     <rect>
+      <x>60</x>
+      <y>20</y>
+      <width>21</width>
+      <height>20</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>kHz</string>
+    </property>
+   </widget>
   </widget>
  </widget>
  <resources/>

--- a/main.cpp
+++ b/main.cpp
@@ -9,7 +9,7 @@ int main(int argc, char *argv[])
     QApplication a(argc, argv);
     QCoreApplication::setOrganizationName("INR");
     QCoreApplication::setApplicationName("HistogramReader");
-    QCoreApplication::setApplicationVersion("3.4 calibration");
+    QCoreApplication::setApplicationVersion("3.5 calibration");
     MainWindow w;
     w.show();
     return a.exec();


### PR DESCRIPTION
The reference rate (either laser or for collisions) can be set in the UI and is taken into account when determining if a given channel is active or inactive (min. number of required entries for a given sleep time).

The changes do compile but I was not able to fully test it because the laser does not appear to be connected to a PMT in the FT0 lab.

![Screenshot from 2022-06-03 07-23-16](https://user-images.githubusercontent.com/7550829/171791686-48d3d5c4-600e-4d99-ada6-e634e3011eb4.png)
